### PR TITLE
Make intropsection cycle-safe

### DIFF
--- a/graphql_server/lib/graphql_server.dart
+++ b/graphql_server/lib/graphql_server.dart
@@ -33,8 +33,8 @@ class GraphQL {
     }
 
     if (introspect) {
-      var allTypes = <GraphQLType>[];
-      allTypes.addAll(this.customTypes);
+      var allTypes = fetchAllTypes(schema, [...this.customTypes]);
+
       _schema = reflectSchema(_schema, allTypes);
 
       for (var type in allTypes.toSet()) {

--- a/graphql_server/lib/introspection.dart
+++ b/graphql_server/lib/introspection.dart
@@ -423,12 +423,19 @@ GraphQLObjectType _reflectEnumValueType() {
 
 List<GraphQLType> fetchAllTypes(
     GraphQLSchema schema, List<GraphQLType> specifiedTypes) {
-  return CollectTypes({
-    schema.queryType,
-    if (schema.mutationType != null) schema.mutationType,
-    if (schema.subscriptionType != null) schema.subscriptionType,
-    ...specifiedTypes,
-  }).types.toList();
+  var data = Set<GraphQLType>()
+    ..add(schema.queryType)
+    ..addAll(specifiedTypes);
+
+  if (schema.mutationType != null) {
+    data.add(schema.mutationType);
+  }
+
+  if (schema.subscriptionType != null) {
+    data.add(schema.subscriptionType);
+  }
+
+  return CollectTypes(data).types.toList();
 }
 
 class CollectTypes {

--- a/graphql_server/pubspec.yaml
+++ b/graphql_server/pubspec.yaml
@@ -4,7 +4,7 @@ author: Tobe O <thosakwe@gmail.com>
 description: Base package for implementing GraphQL servers. You might prefer `package:angel_graphql`, the fastest way to implement GraphQL backends in Dart.
 homepage: https://github.com/angel-dart/graphql
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.0.0 <3.0.0"
 dependencies:
   angel_serialize: ^2.0.0
   collection: ^1.0.0

--- a/graphql_server/pubspec.yaml
+++ b/graphql_server/pubspec.yaml
@@ -4,7 +4,7 @@ author: Tobe O <thosakwe@gmail.com>
 description: Base package for implementing GraphQL servers. You might prefer `package:angel_graphql`, the fastest way to implement GraphQL backends in Dart.
 homepage: https://github.com/angel-dart/graphql
 environment:
-  sdk: ">=1.8.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 dependencies:
   angel_serialize: ^2.0.0
   collection: ^1.0.0


### PR DESCRIPTION
wraps type introspection utilities `_fetchAllTypesFromObject` and `_fetchAllTypesFromType` in a simple `CollectTypes` so that they can avoid infinite loops due to cycles